### PR TITLE
Add stronger types via generics

### DIFF
--- a/src/types-bag.ts
+++ b/src/types-bag.ts
@@ -1,0 +1,4 @@
+export type Fn = (...args: any[]) => any;
+export type FnsBag = {
+    [methodName: string]: Fn;
+};

--- a/src/types-envelope.ts
+++ b/src/types-envelope.ts
@@ -15,30 +15,32 @@
     * // TODO: stream-related envelopes types: start, cancel, data, end, etc
 */
 
+import { Fn, FnsBag } from './types-bag.ts';
+
 export type EnvelopeKind =
     | 'NOTIFY'
     | 'REQUEST'
     | 'RESPONSE';
 
-export interface EnvelopeNotify {
+export interface EnvelopeNotify<BagType extends FnsBag, Method extends keyof BagType> {
     kind: 'NOTIFY';
     fromDeviceId: string;
     envelopeId: string;
-    method: string;
-    args: any[];
+    method: Method;
+    args: Parameters<BagType[Method]>;
 }
-export interface EnvelopeRequest {
+export interface EnvelopeRequest<BagType extends FnsBag, Method extends keyof BagType> {
     kind: 'REQUEST';
     fromDeviceId: string;
     envelopeId: string;
-    method: string;
-    args: any[];
+    method: Method;
+    args: Parameters<BagType[Method]>;
 }
-export interface EnvelopeResponseWithData {
+export interface EnvelopeResponseWithData<BagType extends FnsBag, Method extends keyof BagType> {
     kind: 'RESPONSE';
     fromDeviceId: string;
     envelopeId: string;
-    data: any;
+    data: ReturnType<BagType[Method]>;
 }
 export interface EnvelopeResponseWithError {
     kind: 'RESPONSE';
@@ -46,12 +48,12 @@ export interface EnvelopeResponseWithError {
     envelopeId: string;
     error: string;
 }
-export type EnvelopeResponse =
-    | EnvelopeResponseWithData
+export type EnvelopeResponse<BagType extends FnsBag> =
+    | EnvelopeResponseWithData<BagType, keyof BagType>
     | EnvelopeResponseWithError;
 
-export type Envelope =
-    | EnvelopeNotify
-    | EnvelopeRequest
-    | EnvelopeResponseWithData
+export type Envelope<BagType extends FnsBag> =
+    | EnvelopeNotify<BagType, keyof BagType>
+    | EnvelopeRequest<BagType, keyof BagType>
+    | EnvelopeResponseWithData<BagType, keyof BagType>
     | EnvelopeResponseWithError;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,17 +1,17 @@
 import { Envelope } from './types-envelope.ts';
+import { Fn, FnsBag } from './types-bag.ts';
 import { Watchable } from './watchable.ts';
 
 export type Thunk = () => void;
-export type Fn = (...args: any[]) => any;
 
 /**
  * Typical options for the Transport constructor.
  *
  * But note that each flavor of Transport will have a slightly different constructor
  */
-export interface ITransportOpts {
+export interface ITransportOpts<BagType extends FnsBag> {
     deviceId: string; // id of this device
-    methods: { [methodName: string]: Fn };
+    methods: BagType;
     //streams: { [method: string]: Fn },
 }
 
@@ -21,13 +21,13 @@ export interface ITransportOpts {
  * Creates Connections.
  */
 export type TransportStatus = 'OPEN' | 'CLOSED';
-export interface ITransport {
+export interface ITransport<BagType extends FnsBag> {
     status: Watchable<TransportStatus>;
     isClosed: boolean;
 
-    methods: { [methodName: string]: Fn };
+    methods: BagType;
     deviceId: string;
-    connections: IConnection[];
+    connections: IConnection<BagType>[];
 
     onClose(cb: Thunk): Thunk;
     close(): void;
@@ -35,14 +35,14 @@ export interface ITransport {
     // constructor(opts: ITransportOpts)
 }
 
-export interface ConnectionOpts {
+export interface ConnectionOpts<BagType extends FnsBag> {
     description: string;
-    transport: ITransport;
+    transport: ITransport<BagType>;
     deviceId: string;
-    methods: { [methodName: string]: Fn };
+    methods: BagType;
 
     // conn will be "this"
-    sendEnvelope: (conn: IConnection, env: Envelope) => Promise<void>;
+    sendEnvelope: (conn: IConnection<BagType>, env: Envelope<BagType>) => Promise<void>;
 }
 
 /**
@@ -65,7 +65,9 @@ export type ConnectionStatus =
  *
  * Represents a one-to-one network connection.
  */
-export interface IConnection {
+export interface IConnection<
+    MethodsType extends FnsBag,
+> {
     // TODO: actually connections need to track their incoming and outgoing
     // statuses separately, and then exposed a combined status somehow?
     // What if only one direction has an error?
@@ -74,7 +76,7 @@ export interface IConnection {
     _closeCbs: Set<Thunk>;
 
     description: string;
-    _transport: ITransport;
+    _transport: ITransport<MethodsType>;
     _deviceId: string;
     _otherDeviceId: string | null; // null until we discover it
     _methods: { [methodName: string]: Fn };
@@ -84,19 +86,25 @@ export interface IConnection {
     onClose(cb: Thunk): Thunk;
     close(): void;
 
-    _sendEnvelope: (conn: IConnection, env: Envelope) => Promise<void>; // the transport provides this function for us
+    _sendEnvelope: (conn: IConnection<MethodsType>, env: Envelope<MethodsType>) => Promise<void>; // the transport provides this function for us
 
     // constructor(transport: ITransport);
 
-    handleIncomingEnvelope(env: Envelope): Promise<void>;
+    handleIncomingEnvelope(env: Envelope<MethodsType>): Promise<void>;
 
     // TODO: maybe this can be synchronous since
     // we don't care about the result --
     // does it wait until sent over the network, or just queued in a batch?
-    notify(method: string, ...args: any[]): Promise<void>;
+    notify<MethodKey extends keyof MethodsType>(
+        method: MethodKey,
+        ...args: Parameters<MethodsType[MethodKey]>
+    ): Promise<void>;
 
     // Wait for the return value to come back
-    request(method: string, ...args: any[]): Promise<any>;
+    request<MethodKey extends keyof MethodsType>(
+        method: MethodKey,
+        ...args: Parameters<MethodsType[MethodKey]>
+    ): Promise<ReturnType<MethodsType[MethodKey]>>;
 
     // TODO: stream
 }


### PR DESCRIPTION
## What's the problem you solved?

Currently the following issues are not caught by Typescript:
- Calling a non-existent method on a `Connection#notify` or `Connection#request`
- Providing arguments of the wrong type or length to `Connection#notify` or `Connection#request`

And the following types return vague types or any:
- `Transport.methods`
- `EnvelopeResponseWithData.data`
- `EnvelopeRequest.method`
- `EnvelopeRequest.args`

## What solution are you recommending?

![CleanShot 2022-01-26 at 15 05 32](https://user-images.githubusercontent.com/579491/151177505-d72113b7-e6a8-4b8d-b913-33abd60b6490.gif)

We can infer the types of all these things because we know the type of the bag of methods being passed around. I've added generic typings to many classes so that these errors are caught — I hope it will save us from many little issues as we integrate this library with Earthstar!

I know that it adds a _lot_ of angle brackets, but I hope the improvement in compiler feedback is worth it.