### PR TITLE
Watchable set

### DIFF
--- a/examples/example-http-client.ts
+++ b/examples/example-http-client.ts
@@ -28,6 +28,16 @@ const main = async () => {
         deviceId,
         methods,
     });
+    transportClient.connections.onAdd(conn => {
+        log(`onAdd connection: ${conn.description}`);
+    });
+    transportClient.connections.onDelete(conn => {
+        log(`onDelete connection: ${conn.description}`);
+    });
+    transportClient.connections.onChange(() => {
+        log(`onChange connections`);
+    });
+
     const conn = transportClient.addConnection(serverUrl);
 
     while (true) {

--- a/examples/example.ts
+++ b/examples/example.ts
@@ -59,7 +59,7 @@ const main = async () => {
     log('request-response from server to client');
 
     try {
-        const connServerToClient = transServer.connections[0];
+        const connServerToClient = [...transServer.connections][0];  // a hack to get the connection
         const thirty = await connServerToClient.request('add', 10, 20);
         log('response:', thirty);
     } catch (error) {

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -53,11 +53,8 @@ export class Connection<BagType extends FnsBag> implements IConnection<BagType> 
         log(`${this.description} | closing...`);
         this.status.set('CLOSED');
         for (const cb of this._closeCbs) cb();
-        this._closeCbs = new Set();
-        // remove from transport's list of connections
-        this._transport.connections = this._transport.connections.filter(
-            (c) => c !== this,
-        );
+        this._closeCbs.clear();
+        // the transport is responsible for removing this connection from transport.collections
         log(`${this.description} | ...closed.`);
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { Envelope } from './types-envelope.ts';
 import { Fn, FnsBag } from './types-bag.ts';
-import { Watchable } from './watchable.ts';
+import { Watchable, WatchableSet } from './watchable.ts';
 
 export type Thunk = () => void;
 
@@ -28,7 +28,7 @@ export interface ITransport<BagType extends FnsBag> {
 
     methods: BagType;
     deviceId: string;
-    connections: IConnection<BagType>[];
+    connections: WatchableSet<IConnection<BagType>>;
 
     onClose(cb: Thunk): Thunk;
     close(): void;

--- a/src/watchable.ts
+++ b/src/watchable.ts
@@ -44,7 +44,7 @@ export class WatchableSet<T> extends Set<T> {
     _addCbs: Set<CbValue<T>> = new Set();
     _deleteCbs: Set<CbValue<T>> = new Set();
     _changeCbs: Set<Thunk> = new Set();
-    constructor(iterable: Iterable<T>) {
+    constructor(iterable?: Iterable<T>) {
         super(iterable);
     }
     add(value: T) {

--- a/src/watchable.ts
+++ b/src/watchable.ts
@@ -1,12 +1,13 @@
 type Thunk = () => void;
-type Cb<T> = (oldVal: T, newVal: T) => void;
+type CbOldNew<T> = (oldVal: T, newVal: T) => void;
+type CbValue<T> = (value: T) => void;
 
 export class Watchable<T> {
     value: T;
     // general onChange callbacks
-    _cbs: Set<Cb<T>> = new Set();
+    _cbs: Set<CbOldNew<T>> = new Set();
     // targeted callbacks (onChangeTo)
-    _cbsByTarget: Map<any, Set<Cb<T>>> = new Map();
+    _cbsByTarget: Map<any, Set<CbOldNew<T>>> = new Map();
     constructor(val: T) {
         this.value = val;
     }
@@ -17,28 +18,71 @@ export class Watchable<T> {
         const oldVal = this.value;
         this.value = newVal;
         if (oldVal !== this.value) {
-            for (const cb of this._cbs) {
-                cb(oldVal, this.value);
-            }
+            this._cbs.forEach(cb => cb(oldVal, newVal));
             const cbsByTarget = this._cbsByTarget.get(newVal);
             if (cbsByTarget) {
-                for (const cb of cbsByTarget) {
-                    cb(oldVal, newVal);
-                }
+                cbsByTarget.forEach(cb => cb(oldVal, newVal));
             }
         }
     }
-    onChange(cb: Cb<T>): Thunk {
+    onChange(cb: CbOldNew<T>): Thunk {
         this._cbs.add(cb);
         return () => this._cbs.delete(cb);
     }
-    onChangeTo(target: any, cb: Cb<T>): Thunk {
+    onChangeTo(target: any, cb: CbOldNew<T>): Thunk {
         // this uses strict equality
-        const cbsByTarget = this._cbsByTarget.get(target) ?? new Set<Cb<T>>();
+        const cbsByTarget = this._cbsByTarget.get(target) ?? new Set<CbOldNew<T>>();
         cbsByTarget.add(cb);
         this._cbsByTarget.set(target, cbsByTarget);
         return () => {
             this._cbsByTarget.get(target)?.delete(cb);
         };
+    }
+}
+
+export class WatchableSet<T> extends Set<T> {
+    _addCbs: Set<CbValue<T>> = new Set();
+    _deleteCbs: Set<CbValue<T>> = new Set();
+    _changeCbs: Set<Thunk> = new Set();
+    constructor(iterable: Iterable<T>) {
+        super(iterable);
+    }
+    add(value: T) {
+        let had = super.has(value);
+        super.add(value);
+        if (!had) {
+            this._addCbs.forEach(cb => cb(value));
+            this._changeCbs.forEach(cb => cb());
+        }
+        return this;
+    }
+    delete(value: T) {
+        let had = super.has(value);
+        super.delete(value);
+        if (had) {
+            this._deleteCbs.forEach(cb => cb(value));
+            this._changeCbs.forEach(cb => cb());
+        }
+        return had;
+    }
+    clear() {
+        for (let value of super.values()) {
+            super.delete(value);
+            this._deleteCbs.forEach(cb => cb(value));
+        }
+        this._changeCbs.forEach(cb => cb());
+    }
+
+    onAdd(cb: CbValue<T>) {
+        this._addCbs.add(cb);
+        return () => this._addCbs.delete(cb);
+    }
+    onDelete(cb: CbValue<T>) {
+        this._deleteCbs.add(cb);
+        return () => this._deleteCbs.delete(cb);
+    }
+    onChange(cb: Thunk) {
+        this._changeCbs.add(cb);
+        return () => this._changeCbs.delete(cb);
     }
 }


### PR DESCRIPTION
## What's the problem you solved?
Users of this API need a way to know when a Transport has added or removed a Connection.  This isn't really needed for client-side transports since you have to ask them to add a connection in the first place, but it's need for server-side transports since they accept connections on their own.

## What solution are you recommending?
`transport.connections` has been changed from an array to a [`WatchableSet`](https://github.com/earthstar-project/earthstar-streaming-rpc/blob/main/src/watchable.ts#L43).

A WatchableSet is a subclass of Set, with added methods for subscribing to add, delete, and change events.

```ts
transport.connections.onAdd(conn => { /* ... */ });
```