### PR TITLE
Add TransportBroadcastChannel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ lint:
 	deno lint --rules-exclude=no-explicit-any,no-unused-vars,no-empty,no-inferrable-types,require-await *.ts scripts src
 
 test:
-	deno test -A --no-check=remote --allow-net --unstable src
+	deno test -A --no-check=remote --allow-net --unstable --allow-env src
 
 test-watch:
-	deno test -A --no-check=remote --allow-net --unstable --watch src
+	deno test -A --no-check=remote --allow-net --unstable --watch --allow-env src
 
 test-coverage:
 	deno test -A --no-check=remote --unstable --coverage=cov_profile src

--- a/mod.ts
+++ b/mod.ts
@@ -6,6 +6,7 @@ export * from './src/transport-http-server-opine.ts';
 export * from './src/transport-local.ts';
 export * from './src/transport-websocket-client.ts';
 export * from './src/transport-websocket-server.ts';
+export * from './src/transport-broadcast-channel.ts';
 export * from './src/types-envelope.ts';
 export * from './src/types.ts';
 export * from './src/types-bag.ts';

--- a/src/test/connection.test.ts
+++ b/src/test/connection.test.ts
@@ -141,6 +141,8 @@ Deno.test('connection behaviour', async (t) => {
     for await (const Scenario of scenarios) {
         const scenarioInst = new Scenario(methods);
 
+        await scenarioInst.prepare();
+
         await testConnectionNotify(t, scenarioInst, eventLog);
         await testConnectionRequestResponse(t, scenarioInst, eventLog);
         await testClosingConnection(t, scenarioInst);

--- a/src/test/scenario-types.ts
+++ b/src/test/scenario-types.ts
@@ -7,5 +7,6 @@ export interface ITransportScenario<BagType extends FnsBag> {
     connBtoA: IConnection<BagType> | null;
     clientTransport: ITransport<BagType>;
     serverTransport: ITransport<BagType>;
+    prepare: () => Promise<void>;
     teardown: () => Promise<void>;
 }

--- a/src/test/scenarios.node.ts
+++ b/src/test/scenarios.node.ts
@@ -45,6 +45,10 @@ class TransportHttpExpressScenario<BagType extends FnsBag> implements ITransport
         this.serverTransport = serverTransport;
     }
 
+    prepare() {
+        return Promise.resolve();
+    }
+
     teardown() {
         this.serverTransport.close();
         this.clientTransport.close();

--- a/src/test/scenarios.ts
+++ b/src/test/scenarios.ts
@@ -154,6 +154,10 @@ class TransportWebsocketScenario<BagType extends FnsBag> implements ITransportSc
         this.connAtoB = this.clientTransport.addConnection(SERVER_URL);
     }
 
+    prepare() {
+        return Promise.resolve();
+    }
+
     teardown() {
         this.serverTransport.close();
         this.clientTransport.close();

--- a/src/test/scenarios.ts
+++ b/src/test/scenarios.ts
@@ -6,7 +6,10 @@ import { TransportHttpServer } from '../transport-http-server.ts';
 import { TransportHttpServerOpine } from '../transport-http-server-opine.ts';
 import { TransportWebsocketServer } from '../transport-websocket-server.ts';
 import { TransportWebsocketClient } from '../transport-websocket-client.ts';
-import { TransportLocalScenario } from './scenarios.universal.ts';
+import {
+    TransportBroadcastChannelScenario,
+    TransportLocalScenario,
+} from './scenarios.universal.ts';
 
 import { sleep } from '../util.ts';
 import { serve } from 'https://deno.land/std@0.123.0/http/mod.ts';
@@ -48,6 +51,10 @@ class TransportHttpScenario<BagType extends FnsBag> implements ITransportScenari
         this.connBtoA = connBtoA;
         this.clientTransport = clientTransport;
         this.serverTransport = serverTransport;
+    }
+
+    prepare() {
+        return Promise.resolve();
     }
 
     teardown() {
@@ -96,6 +103,10 @@ class TransportHttpOpineScenario<BagType extends FnsBag> implements ITransportSc
 
         this.clientTransport = clientTransport;
         this.serverTransport = serverTransport;
+    }
+
+    prepare() {
+        return Promise.resolve();
     }
 
     teardown() {
@@ -153,6 +164,7 @@ class TransportWebsocketScenario<BagType extends FnsBag> implements ITransportSc
 
 export const scenarios = [
     TransportLocalScenario,
+    TransportBroadcastChannelScenario,
     TransportHttpScenario,
     TransportHttpOpineScenario,
     TransportWebsocketScenario,

--- a/src/test/scenarios.universal.ts
+++ b/src/test/scenarios.universal.ts
@@ -2,6 +2,8 @@ import { ITransportScenario } from './scenario-types.ts';
 import { FnsBag } from '../types-bag.ts';
 import { IConnection, ITransport } from '../types.ts';
 import { makeLocalTransportPair } from '../transport-local.ts';
+import { TransportBroadcastChannel } from '../transport-broadcast-channel.ts';
+import { sleep } from '../util.ts';
 
 export class TransportLocalScenario<BagType extends FnsBag> implements ITransportScenario<BagType> {
     name = 'TransportLocal';
@@ -23,9 +25,76 @@ export class TransportLocalScenario<BagType extends FnsBag> implements ITranspor
         this.serverTransport = serverTransport;
     }
 
+    prepare() {
+        return Promise.resolve();
+    }
+
     teardown() {
         this.clientTransport.close();
         this.serverTransport.close();
+
+        return Promise.resolve();
+    }
+}
+
+export class TransportBroadcastChannelScenario<BagType extends FnsBag>
+    implements ITransportScenario<BagType> {
+    name = 'TransportBroadcastChannel';
+    connAtoB: IConnection<BagType>;
+    connBtoA: IConnection<BagType>;
+    clientTransport: TransportBroadcastChannel<BagType>;
+    serverTransport: TransportBroadcastChannel<BagType>;
+    _andAnotherOne: TransportBroadcastChannel<BagType>;
+    constructor(methods: BagType) {
+        const clientTransport = new TransportBroadcastChannel({
+            methods,
+            deviceId: 'bchannel-test-client',
+            channel: 'testing',
+        });
+
+        const serverTransport = new TransportBroadcastChannel({
+            methods,
+            deviceId: 'bchannel-test-server',
+            channel: 'testing',
+        });
+
+        this._andAnotherOne = new TransportBroadcastChannel({
+            methods,
+            deviceId: 'heheh-test-server',
+            channel: 'testing',
+        });
+
+        const connAtoB: IConnection<typeof methods> = null as unknown as IConnection<
+            typeof methods
+        >;
+        this.connAtoB = connAtoB;
+        const connBtoA: IConnection<typeof methods> = null as unknown as IConnection<
+            typeof methods
+        >;
+        this.connBtoA = connBtoA;
+
+        clientTransport.connections.onAdd((conn) => {
+            this.connAtoB = conn;
+        });
+        serverTransport.connections.onAdd((conn) => {
+            this.connBtoA = conn;
+        });
+
+        this.clientTransport = clientTransport;
+        this.serverTransport = serverTransport;
+    }
+
+    async prepare() {
+        this.clientTransport.register();
+        this.serverTransport.register();
+        this._andAnotherOne.register();
+        await sleep(10);
+    }
+
+    teardown() {
+        this.clientTransport.close();
+        this.serverTransport.close();
+        this._andAnotherOne.close();
 
         return Promise.resolve();
     }

--- a/src/test/scenarios.universal.ts
+++ b/src/test/scenarios.universal.ts
@@ -85,9 +85,6 @@ export class TransportBroadcastChannelScenario<BagType extends FnsBag>
     }
 
     async prepare() {
-        this.clientTransport.register();
-        this.serverTransport.register();
-        this._andAnotherOne.register();
         await sleep(10);
     }
 

--- a/src/transport-broadcast-channel.ts
+++ b/src/transport-broadcast-channel.ts
@@ -119,16 +119,7 @@ export class TransportBroadcastChannel<BagType extends FnsBag> implements ITrans
             },
         });
 
-        const onEvent = (event: MessageEvent<TransportMessage<BagType>>) => {
-            if (isEnvelopeMessage(event.data)) {
-                conn.handleIncomingEnvelope(event.data.envelope);
-            }
-        };
-
-        this._channel.addEventListener('message', onEvent);
-
         conn.onClose(() => {
-            this._channel.removeEventListener('message', onEvent);
             this.connections.delete(conn);
         });
 

--- a/src/transport-broadcast-channel.ts
+++ b/src/transport-broadcast-channel.ts
@@ -1,0 +1,135 @@
+import { RpcErrorUseAfterClose } from './errors.ts';
+import { FnsBag } from './types-bag.ts';
+import { IConnection, ITransport, ITransportOpts, Thunk, TransportStatus } from './types.ts';
+import { Envelope } from './types-envelope.ts';
+import { Watchable, WatchableSet } from './watchable.ts';
+import { Connection } from './connection.ts';
+
+import { logTransport as log } from './log.ts';
+
+type TransportMessage<BagType extends FnsBag> = {
+    envelope: Envelope<BagType>;
+} | { deviceId: string };
+
+function isEnvelopeMessage<BagType extends FnsBag>(message: TransportMessage<BagType>): message is {
+    envelope: Envelope<BagType>;
+} {
+    if ('envelope' in message) {
+        return true;
+    }
+
+    return false;
+}
+
+export interface ITransportBroadcastChannelOpts<BagType extends FnsBag>
+    extends ITransportOpts<BagType> {
+    channel: string;
+}
+
+export class TransportBroadcastChannel<BagType extends FnsBag> implements ITransport<BagType> {
+    status: Watchable<TransportStatus> = new Watchable('OPEN' as TransportStatus);
+    deviceId: string;
+    methods: BagType;
+    connections: WatchableSet<IConnection<BagType>> = new WatchableSet();
+    _channel: BroadcastChannel;
+
+    constructor(opts: ITransportBroadcastChannelOpts<BagType>) {
+        this.deviceId = opts.deviceId;
+        this.methods = opts.methods;
+
+        this._channel = new BroadcastChannel(opts.channel);
+
+        const onEvent = (event: MessageEvent<TransportMessage<BagType>>) => {
+            if (isEnvelopeMessage(event.data)) {
+                const connection = this._addOrGetConnection(event.data.envelope.fromDeviceId);
+                connection.handleIncomingEnvelope(event.data.envelope);
+                return;
+            }
+
+            this._addOrGetConnection(event.data.deviceId);
+        };
+
+        this._channel.addEventListener('message', onEvent);
+
+        this.onClose(() => {
+            this._channel.close();
+            this._channel.removeEventListener('message', onEvent);
+        });
+    }
+
+    get isClosed() {
+        return this.status.value === 'CLOSED';
+    }
+
+    onClose(cb: Thunk): Thunk {
+        return this.status.onChangeTo('CLOSED', cb);
+    }
+
+    close(): void {
+        if (this.isClosed) return;
+
+        log('closing...');
+        this.status.set('CLOSED');
+
+        log('...closing connections...');
+        for (const conn of this.connections) {
+            conn.close();
+        }
+        log('...closed');
+    }
+
+    register() {
+        log(`Registering ${this.deviceId} on "${this._channel.name}"...`);
+        this._channel.postMessage({ deviceId: this.deviceId });
+    }
+
+    _addOrGetConnection(otherDeviceId: string): IConnection<BagType> {
+        for (const conn of this.connections) {
+            if (conn._otherDeviceId === otherDeviceId) {
+                log('Connection exists already');
+                conn._lastSeen = Date.now();
+                conn.status.set('OPEN');
+                return conn;
+            }
+        }
+
+        log('Connection does not exist already.  Making a new one.');
+        const conn = new Connection({
+            description: `connection to ${otherDeviceId}`,
+            transport: this,
+            deviceId: this.deviceId,
+            methods: this.methods,
+            sendEnvelope: (_conn, envelope) => {
+                if (conn.isClosed) throw new RpcErrorUseAfterClose('the connection is closed');
+                log(`connection "${conn.description}" is sending an envelope:`, envelope);
+                log('send...');
+
+                conn.status.set('CONNECTING');
+
+                this._channel.postMessage({ envelope });
+
+                return Promise.resolve();
+            },
+        });
+
+        const onEvent = (event: MessageEvent<TransportMessage<BagType>>) => {
+            if (isEnvelopeMessage(event.data)) {
+                conn.handleIncomingEnvelope(event.data.envelope);
+            }
+        };
+
+        this._channel.addEventListener('message', onEvent);
+
+        conn.onClose(() => {
+            this._channel.removeEventListener('message', onEvent);
+            this.connections.delete(conn);
+        });
+
+        conn._otherDeviceId = otherDeviceId;
+        conn._lastSeen = Date.now();
+        conn.status.set('OPEN');
+
+        this.connections.add(conn);
+        return conn;
+    }
+}

--- a/src/transport-broadcast-channel.ts
+++ b/src/transport-broadcast-channel.ts
@@ -25,9 +25,13 @@ function isEnvelopeMessage<BagType extends FnsBag>(message: TransportMessage<Bag
 
 export interface ITransportBroadcastChannelOpts<BagType extends FnsBag>
     extends ITransportOpts<BagType> {
+    /** The channel for this transport's BroadcastChannel instance to join. */
     channel: string;
 }
 
+/** A Transport that connects to other transports using the same BroadcastChannel channel in other tabs or windowns on the same machine.
+ * Many TransportBroadcastChannel can join the same channel to comunicate.
+ */
 export class TransportBroadcastChannel<BagType extends FnsBag> implements ITransport<BagType> {
     status: Watchable<TransportStatus> = new Watchable('OPEN' as TransportStatus);
     deviceId: string;
@@ -42,15 +46,19 @@ export class TransportBroadcastChannel<BagType extends FnsBag> implements ITrans
         this._channel = new BroadcastChannel(opts.channel);
 
         const onEvent = (event: MessageEvent<TransportMessage<BagType>>) => {
+            // If the event contains envelope data...
             if (isEnvelopeMessage(event.data)) {
+                // Make sure we're the intnded recipient...
                 if (event.data.forDeviceId === this.deviceId) {
                     const connection = this._addOrGetConnection(event.data.envelope.fromDeviceId);
+                    // ... and handle it.
                     connection.handleIncomingEnvelope(event.data.envelope);
                 }
-
+                // This envelope wasn't for us!
                 return;
             }
 
+            // This was just another TransportBroadcastChannel telling us it exists.
             this._addOrGetConnection(event.data.deviceId);
         };
 
@@ -85,6 +93,7 @@ export class TransportBroadcastChannel<BagType extends FnsBag> implements ITrans
         log('...closed');
     }
 
+    /** Ping other transports on the same BroadcastChannel to make them create a connection to this one. */
     register() {
         log(`Registering ${this.deviceId} on "${this._channel.name}"...`);
         this._channel.postMessage({ deviceId: this.deviceId });
@@ -113,6 +122,7 @@ export class TransportBroadcastChannel<BagType extends FnsBag> implements ITrans
 
                 conn.status.set('CONNECTING');
 
+                // Send the envelope along with an ID indicating the intended recipient.
                 this._channel.postMessage({ envelope, forDeviceId: otherDeviceId });
 
                 return Promise.resolve();

--- a/src/transport-broadcast-channel.ts
+++ b/src/transport-broadcast-channel.ts
@@ -42,7 +42,9 @@ export class TransportBroadcastChannel<BagType extends FnsBag> implements ITrans
         const onEvent = (event: MessageEvent<TransportMessage<BagType>>) => {
             if (isEnvelopeMessage(event.data)) {
                 const connection = this._addOrGetConnection(event.data.envelope.fromDeviceId);
+
                 connection.handleIncomingEnvelope(event.data.envelope);
+
                 return;
             }
 
@@ -55,6 +57,8 @@ export class TransportBroadcastChannel<BagType extends FnsBag> implements ITrans
             this._channel.close();
             this._channel.removeEventListener('message', onEvent);
         });
+
+        this.register();
     }
 
     get isClosed() {


### PR DESCRIPTION
## What's the problem you solved?

There was no transport for communication between windows or tabs on the same origin! Weird!

## What solution are you recommending?

I've added a `TransportBroadcastChannel` transport. It's a bit like `TransportLocal` in that it has neither a server or client role, it's just one class. You can have multiple transports join the same broadcast channel without the devices getting their messages mixed up for each other. It's fun!

There is a flakey test in here though. Something is going wrong with a promise, and I can't track it down. @cinnamon-bun Is there anything I'm missing in my implementation that could cause something like that?

Closes #4 