### PR TITLE
Add Websocket transports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ cov.lcov
 cov_profile/
 cov_html/
 npm/*
-*.bundle.js
+*bundle.js
+bundle.js

--- a/examples/example-websocket-client.ts
+++ b/examples/example-websocket-client.ts
@@ -29,12 +29,14 @@ const main = async () => {
         deviceId,
         methods,
     });
-    const conn = transportClient.addConnection(serverUrl);
+    transportClient.addConnection(serverUrl);
 
     while (true) {
+        const conn = [...transportClient.connections][0];
+        const status = (conn === undefined) ? 'RECONNECTING' : conn.status.get();
         log('----------------------------------------');
-        log('|   connection status:', conn.status.get());
-        if (conn.status.get() === 'OPEN') {
+        log('|   connection status:', status);
+        if (status === 'OPEN') {
             log('calling from client to server');
             try {
                 log('|   notify: shouting to server...');

--- a/examples/example-websocket-client.ts
+++ b/examples/example-websocket-client.ts
@@ -1,0 +1,53 @@
+import { makeId, sleep, TransportWebsocketClient } from '../mod.ts';
+
+//import { logMain as log } from './src/log.ts';
+const log = console.log;
+
+const main = async () => {
+    log('----------------------------------------');
+    log('setting up basic variables');
+
+    const deviceId = 'client:' + makeId();
+    const methods = {
+        shout: (s: string) => console.log(`!! ${s.toLocaleUpperCase()} !!`),
+        hello: (name: string) => `hello ${name}!`,
+        add: (x: number, y: number) => x + y,
+    };
+    const port = 8008;
+    const path = '/earthstar-api/v2/ws';
+    const serverUrl = `ws://localhost:${port}${path}`;
+    log('|   deviceId:', deviceId);
+    log('|   methods:', Object.keys(methods));
+    log('|   port:', port);
+    log('|   path:', path);
+    log('|   serverUrl:', serverUrl);
+
+    log('----------------------------------------');
+    log('making TransportWebsocketClient and Connection');
+
+    const transportClient = new TransportWebsocketClient({
+        deviceId,
+        methods,
+    });
+    const conn = transportClient.addConnection(serverUrl);
+
+    while (true) {
+        log('----------------------------------------');
+        log('|   connection status:', conn.status.get());
+        if (conn.status.get() === 'OPEN') {
+            log('calling from client to server');
+            try {
+                log('|   notify: shouting to server...');
+                await conn.notify('shout', `this is a notify from ${transportClient.deviceId}`);
+                log('|   request: add(1, 2)...');
+                const three = await conn.request('add', 1, 2);
+                log('|   ...response:', three);
+            } catch (error) {
+                log('|   ...caught an error during notify or request:');
+                log(error);
+            }
+        }
+        await sleep(3000);
+    }
+};
+main();

--- a/examples/example-websocket-server.ts
+++ b/examples/example-websocket-server.ts
@@ -1,0 +1,63 @@
+import { serve } from 'https://deno.land/std@0.123.0/http/mod.ts';
+import { makeId, sleep, TransportWebsocketServer } from '../mod.ts';
+
+//import { logMain as log } from './src/log.ts';
+const log = console.log;
+
+const main = async () => {
+    log('----------------------------------------');
+    log('setting up basic variables');
+
+    const deviceId = 'server:' + makeId();
+    const methods = {
+        shout: (s: string) => console.log(`!! ${s.toLocaleUpperCase()} !!`),
+        hello: (name: string) => `hello ${name}!`,
+        add: (x: number, y: number) => x + y,
+    };
+    const port = 8008;
+    const path = '/earthstar-api/v2/ws';
+    const serverUrl = `ws://localhost:${port}${path}`;
+    log('|   deviceId:', deviceId);
+    log('|   methods:', Object.keys(methods));
+    log('|   port:', port);
+    log('|   path:', path);
+    log('|   serverUrl:', serverUrl);
+
+    log('----------------------------------------');
+    log('making TransportWebsocketServer');
+
+    const transportServer = new TransportWebsocketServer({
+        deviceId,
+        methods,
+        url: serverUrl,
+    });
+    serve(transportServer.reqHandler, { port });
+
+    while (true) {
+        const connections = transportServer.connections;
+        log('----------------------------------------');
+        log('|   server status:', transportServer.status.get());
+        log(`|   ${connections.size} connections:`);
+        for (const conn of connections) {
+            log(`|   |   ${conn.status.get()} - ${conn.description}`);
+        }
+
+        /*
+        for (let conn of transportServer.connections) {
+            try {
+                log(`|   notify: shouting to ${conn.description}`);
+                await conn.notify('shout', `this is a notify from ${transportServer.deviceId}`);
+                log(`|   request: add(10, 20) to ${conn.description}...`);
+                let thirty = await conn.request('add', 10, 20);
+                log(`|   ...response: ${thirty}`);
+            } catch (error) {
+                log('|   ...caught an error during notify or request:');
+                log(error);
+            }
+        }
+        */
+
+        await sleep(2700);
+    }
+};
+main();

--- a/mod.node.ts
+++ b/mod.node.ts
@@ -3,6 +3,7 @@ export * from './src/errors.ts';
 export * from './src/transport-http-client.ts';
 export * from './src/transport-http-server-express.ts';
 export * from './src/transport-local.ts';
+export * from './src/transport-websocket-client.ts';
 export * from './src/types-envelope.ts';
 export * from './src/types.ts';
 export * from './src/types-bag.ts';

--- a/mod.ts
+++ b/mod.ts
@@ -4,6 +4,8 @@ export * from './src/transport-http-client.ts';
 export * from './src/transport-http-server.ts';
 export * from './src/transport-http-server-opine.ts';
 export * from './src/transport-local.ts';
+export * from './src/transport-websocket-client.ts';
+export * from './src/transport-websocket-server.ts';
 export * from './src/types-envelope.ts';
 export * from './src/types.ts';
 export * from './src/types-bag.ts';

--- a/src/log.ts
+++ b/src/log.ts
@@ -23,3 +23,9 @@ export const logTransport2 = (...args: any[]) => {
         console.log('    ' + crayon.bgLightBlue.black(' transport '), ...args);
     }
 };
+
+export const logWatchable = (...args: any[]) => {
+    if (showLogs) {
+        console.log(crayon.bgRed.black(' watchable '), ...args);
+    }
+};

--- a/src/test/asserts.ts
+++ b/src/test/asserts.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@0.122.0/testing/asserts.ts';
+export * from 'https://deno.land/std@0.123.0/testing/asserts.ts';

--- a/src/transport-websocket-client.ts
+++ b/src/transport-websocket-client.ts
@@ -1,0 +1,116 @@
+import { RpcError, RpcErrorNetworkProblem, RpcErrorUseAfterClose } from './errors.ts';
+import { FnsBag } from './types-bag.ts';
+import { IConnection, ITransport, ITransportOpts, Thunk, TransportStatus } from './types.ts';
+import { Envelope } from './types-envelope.ts';
+import { Watchable, WatchableSet } from './watchable.ts';
+import { ensureEndsWith, setImmediate2, sleep, withTimeout } from './util.ts';
+import { Connection } from './connection.ts';
+
+import { logTransport as log } from './log.ts';
+
+const TIMEOUT = 2000; // TODO: make this configurable
+
+export class TransportWebsocketClient<BagType extends FnsBag> implements ITransport<BagType> {
+    status: Watchable<TransportStatus> = new Watchable('OPEN' as TransportStatus);
+    deviceId: string;
+    methods: BagType;
+    connections: WatchableSet<IConnection<BagType>> = new WatchableSet();
+
+    constructor(opts: ITransportOpts<BagType>) {
+        log('constructor for device', opts.deviceId);
+        this.deviceId = opts.deviceId;
+        this.methods = opts.methods;
+    }
+
+    get isClosed() {
+        return this.status.value === 'CLOSED';
+    }
+    onClose(cb: Thunk): Thunk {
+        return this.status.onChangeTo('CLOSED', cb);
+    }
+    close(): void {
+        if (this.isClosed) return;
+
+        log('closing...');
+        this.status.set('CLOSED');
+
+        log('...closing connections...');
+        for (const conn of this.connections) {
+            conn.close();
+        }
+        log('...closed');
+    }
+
+    addConnection(url: string): Connection<BagType> {
+        log('addConnection to url:', url);
+
+        let ws: WebSocket;
+        try {
+            ws = new WebSocket(url);
+        } catch (error) {
+            throw new RpcErrorNetworkProblem(error);
+        }
+
+        ws.onopen = (e: Event) => {
+            log('>>> ws on open');
+            conn.status.set('OPEN');
+        };
+
+        ws.onmessage = async (e: MessageEvent) => {
+            log('>>> ws on message');
+            conn.status.set('OPEN');
+            let env = JSON.parse(e.data) as Envelope<BagType>;
+            log(`>>> ws on message: it\'s a ${env.kind}`);
+            log(`>>> ws on message: handling...`);
+            await conn.handleIncomingEnvelope(env);
+            log(`>>> ws on message: done`);
+        };
+
+        ws.onerror = (e: Event) => {
+            log('>>> ws on error 2');
+            conn.status.set('ERROR');
+            throw new RpcErrorNetworkProblem('could not connect');
+        };
+
+        ws.onclose = (e: CloseEvent) => {
+            log('>>> ws on close.  closing the connection.');
+            conn.close();
+        };
+
+        const conn = new Connection({
+            description: url,
+            transport: this,
+            deviceId: this.deviceId,
+            methods: this.methods,
+            // PUSH
+            sendEnvelope: async (conn: IConnection<BagType>, env: Envelope<BagType>) => {
+                if (conn.isClosed) throw new RpcErrorUseAfterClose('the connection is closed');
+                log(`connection "${conn.description}" is sending an envelope:`, env);
+                log('waiting for OPEN...');
+                await conn.status.waitUntil('OPEN', TIMEOUT);
+                log('send...');
+                ws.send(JSON.stringify(env));
+                log('...done');
+            },
+        });
+
+        conn.onClose(async () => {
+            log('>>> connection onClose.  closing the ws.');
+            if (ws.bufferedAmount !== 0) {
+                // the websocket still has queued data to send.
+                // give it one more moment to finish sending before we close it.
+                await sleep(1000);
+            }
+            ws.close();
+            this.connections.delete(conn);
+        });
+
+        conn.status.onChange((oldVal, newVal) => {
+            log(`connection status changed from ${oldVal} --> ${newVal}`);
+        });
+
+        this.connections.add(conn);
+        log('...done adding connection');
+        return conn;
+    }
+}

--- a/src/transport-websocket-server.ts
+++ b/src/transport-websocket-server.ts
@@ -1,0 +1,108 @@
+import { RpcError, RpcErrorNetworkProblem, RpcErrorUseAfterClose } from './errors.ts';
+import { FnsBag } from './types-bag.ts';
+import { IConnection, ITransport, ITransportOpts, Thunk, TransportStatus } from './types.ts';
+import { Envelope } from './types-envelope.ts';
+import { Watchable, WatchableSet } from './watchable.ts';
+import { ensureEndsWith, setImmediate2, sleep, withTimeout } from './util.ts';
+import { Connection } from './connection.ts';
+
+import { logTransport as log } from './log.ts';
+
+export interface ITransportWebsocketServerOpts<BagType extends FnsBag> {
+    url: string;
+    deviceId: string; // id of this device
+    methods: BagType;
+    //streams: { [method: string]: Fn },
+}
+
+export class TransportWebsocketServer<BagType extends FnsBag> implements ITransport<BagType> {
+    status: Watchable<TransportStatus> = new Watchable('OPEN' as TransportStatus);
+    deviceId: string;
+    methods: BagType;
+    connections: WatchableSet<IConnection<BagType>> = new WatchableSet();
+    _url: string;
+    reqHandler: any;
+
+    constructor(opts: ITransportWebsocketServerOpts<BagType>) {
+        log('constructor for device', opts.deviceId);
+        this.deviceId = opts.deviceId;
+        this.methods = opts.methods;
+        this._url = opts.url;
+
+        this.reqHandler = (req: Request) => {
+            log(`${req.method} ${req.url}`);
+            if (req.headers.get('upgrade') !== 'websocket') {
+                return new Response(null, { status: 501 });
+            }
+            log('upgrading websocket...');
+            const { socket: ws, response } = Deno.upgradeWebSocket(req);
+            log('...upgrading websocket: done.');
+
+            const conn = new Connection({
+                description: `connection from ?`, // TODO: how to get other device id?  put it in the url again?
+                transport: this,
+                deviceId: this.deviceId,
+                methods: this.methods,
+                sendEnvelope: async (conn, env) => {
+                    // outgoing message
+                    log('conn.sendEnvelope');
+                    ws.send(JSON.stringify(env));
+                },
+            });
+
+            ws.onopen = () => {
+                log('>>> ws.onopen');
+                this.connections.add(conn);
+                conn.status.set('OPEN');
+            };
+
+            ws.onmessage = async (m) => {
+                // incoming message
+                log('>>> ws.onmessage:', m.data);
+                conn.status.set('OPEN');
+                const env = JSON.parse(m.data);
+                log('...ws.onmessage: handling envelope');
+                await conn.handleIncomingEnvelope(env);
+                log('...ws.onmessage: done');
+            };
+
+            ws.onerror = (error) => {
+                log(`>>> ws.onerror: ${(error as any).message}`);
+                conn.status.set('ERROR');
+            };
+
+            ws.onclose = () => {
+                log('>>> ws.onclose');
+                conn.close();
+                this.connections.delete(conn);
+            };
+
+            this.onClose(() => {
+                ws.close();
+                conn.close();
+            });
+
+            return response;
+        };
+    }
+
+    get isClosed() {
+        return this.status.value === 'CLOSED';
+    }
+    onClose(cb: Thunk): Thunk {
+        log('transport.onClose(cb) -- registering callback');
+        return this.status.onChangeTo('CLOSED', cb);
+    }
+    close(): void {
+        if (this.isClosed) return;
+
+        log('closing...');
+        this.status.set('CLOSED');
+
+        log('...closing connections...');
+        for (const conn of this.connections) {
+            conn.close();
+        }
+        log('...closed');
+    }
+}

--- a/src/transport-websocket-server.ts
+++ b/src/transport-websocket-server.ts
@@ -1,9 +1,6 @@
-import { RpcError, RpcErrorNetworkProblem, RpcErrorUseAfterClose } from './errors.ts';
 import { FnsBag } from './types-bag.ts';
-import { IConnection, ITransport, ITransportOpts, Thunk, TransportStatus } from './types.ts';
-import { Envelope } from './types-envelope.ts';
+import { IConnection, ITransport, Thunk, TransportStatus } from './types.ts';
 import { Watchable, WatchableSet } from './watchable.ts';
-import { ensureEndsWith, setImmediate2, sleep, withTimeout } from './util.ts';
 import { Connection } from './connection.ts';
 
 import { logTransport as log } from './log.ts';

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { RpcErrorTimeout } from './errors.ts';
+
 export function fetchWithTimeout(
     timeout: number,
     ...args: Parameters<typeof fetch>
@@ -23,6 +25,17 @@ export function fetchWithTimeout(
 
     return { request, cancel };
 }
+
+export const withTimeout = async <T>(ms: number, prom: Promise<T>): Promise<T> => {
+    let timeout = 0;
+    const rejectAfterMs = new Promise((res, rej) => {
+        timeout = setTimeout(() => rej(new RpcErrorTimeout()), ms);
+    });
+
+    const result = await Promise.race([rejectAfterMs, prom]) as Promise<T>;
+    clearTimeout(timeout);
+    return result;
+};
 
 export const ensureEndsWith = (s: string, suffix: string) => {
     if (s.endsWith(suffix)) return s;


### PR DESCRIPTION
## What's the problem you solved?

There were no transportsusing Websockets, which was a shame because the Websocket API is well suited to our RPC library.

## What solution are you recommending?

@cinnamon-bun built two nice transports using the Websocket API: one for the client and one for the server. I just added tests and a few tiny fixes.

Availability:

Deno: `TransportWebsocketClient`, `TransportWebsocketServer`
Web: `TransportWebsocketClient`
Node: `TransportWebsocketClient` (Server will come later: `Websocket` will be shimmed at some point by https://github.com/denoland/dnt/issues/49)

Closes #2
