### PR TITLE
Refactor TransportHttpClient to use a state machine... kinda...

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -29,3 +29,9 @@ export const logWatchable = (...args: any[]) => {
         console.log(crayon.bgRed.black(' watchable '), ...args);
     }
 };
+
+export const logPullState = (...args: any[]) => {
+    if (Deno.env.get('PULLS') === 'true') {
+        console.log('    ' + crayon.bgLightMagenta.black(' pull state '), ...args);
+    }
+};

--- a/src/transport-http-client.ts
+++ b/src/transport-http-client.ts
@@ -5,17 +5,169 @@ import { Watchable, WatchableSet } from './watchable.ts';
 import { ensureEndsWith, fetchWithTimeout } from './util.ts';
 import { Connection } from './connection.ts';
 
-import { logTransport as log } from './log.ts';
+import { logPullState, logTransport as log } from './log.ts';
 
 const TIMEOUT = 1000; // TODO: make this configurable
+
+interface ClosedPullState {
+    closed: true;
+}
+
+interface PullStateOptions<BagType extends FnsBag> {
+    urlToFetch: string;
+    setState: (
+        state: ScheduledPullState<BagType> | InFlightPullState<BagType> | ClosedPullState,
+    ) => void;
+    connection: IConnection<BagType>;
+}
+
+class ScheduledPullState<BagType extends FnsBag> {
+    closed = false as false;
+    _timeoutId: number;
+    _opts: PullStateOptions<BagType>;
+
+    constructor(opts: PullStateOptions<BagType> & { ms?: number }) {
+        this._opts = opts;
+
+        this._timeoutId = setTimeout(() => {
+            logPullState(
+                `(SCHEDULED -> IN-FLIGHT) Began a pull!`,
+            );
+            this._opts.setState(new InFlightPullState(this._opts));
+        }, opts.ms);
+
+        //logPullState(`(SCHEDULED) Scheduled a pull in ${opts.ms}`);
+    }
+
+    reschedule(ms?: number) {
+        clearTimeout(this._timeoutId);
+
+        if (ms) {
+            logPullState(
+                `(SCHEDULED -> SCHEDULED) Rescheduled a pull in ${ms}ms'}`,
+            );
+            this._opts.setState(
+                new ScheduledPullState({ ms, ...this._opts }),
+            );
+        } else {
+            logPullState(
+                `(SCHEDULED -> IN-FLIGHT) Rescheduled a pull to right now!`,
+            );
+            this._opts.setState(
+                new InFlightPullState({ ...this._opts }),
+            );
+        }
+    }
+
+    close() {
+        clearTimeout(this._timeoutId);
+        this._opts.setState({
+            closed: true,
+        });
+        logPullState(`(SCHEDULED -> CLOSED) Closed while waiting for the next pull!`);
+    }
+}
+
+class InFlightPullState<BagType extends FnsBag> {
+    _abortController: AbortController;
+    _opts: PullStateOptions<BagType>;
+    _timeoutTimer: number;
+    closed = false as false;
+    _closedInMeantime = false;
+
+    constructor(opts: PullStateOptions<BagType>) {
+        this._abortController = new AbortController();
+        this._opts = opts;
+
+        // Cancel the request after a timeout
+        this._timeoutTimer = setTimeout(() => {
+            if (!this._abortController.signal.aborted) {
+                this._abortController.abort();
+            }
+        }, TIMEOUT);
+
+        const QUICK_POLL = 10; // got good data, try again right away
+        const SLOW_POLL = 1000; // got no data, slow down
+        const ERROR_POLL = 3000; // got an error, back off
+
+        fetch(opts.urlToFetch, { signal: this._abortController.signal }).then(async (response) => {
+            logPullState('(IN-FLIGHT) Fetched successfully!');
+
+            if (!response.ok) {
+                console.log(response);
+
+                throw new RpcErrorNetworkProblem('pull thread HTTP response was not ok');
+            }
+
+            const envs = await response.json();
+
+            if (!Array.isArray(envs)) throw new RpcError('expected an array');
+            // poll slower when there's nothing there
+
+            const pollInMs = envs.length >= 1 ? QUICK_POLL : SLOW_POLL;
+
+            logPullState('(IN-FLIGHT) Got this many envelopes:', envs.length);
+            logPullState(`(IN-FLIGHT -> SCHEDULED) Scheduled next pull in ${pollInMs}ms`);
+            this._opts.setState(new ScheduledPullState({ ...this._opts, ms: pollInMs }));
+
+            // pass envelopes to the connection to handle one at a time
+            this._opts.connection.status.set('OPEN');
+            log(`got ${envs.length} envelopes`);
+            for (const env of envs) {
+                this._opts.connection.handleIncomingEnvelope(env);
+            }
+        }).catch((error) => {
+            // This will happen if this state was closed
+            // or timed out.
+            if (
+                error instanceof DOMException &&
+                error.message === 'The signal has been aborted'
+            ) {
+                logPullState('(IN-FLIGHT) Request was cancelled.');
+                return;
+            }
+
+            this._opts.connection.status.set('ERROR');
+
+            // here we should reschedule if this wasn't closed in the meantime.
+
+            logPullState('Got an error!:', error);
+            if (!this._closedInMeantime) {
+                logPullState(
+                    `(IN-FLIGHT -> SCHEDULED) Scheduled next pull in ${ERROR_POLL}ms (due to error)`,
+                );
+                this._opts.setState(new ScheduledPullState({ ...this._opts, ms: ERROR_POLL }));
+            }
+
+            console.warn('> problem polling for envelopes:', error);
+            // don't re-throw; swallow this error because there's nobody to catch it
+        }).finally(() => {
+            clearTimeout(this._timeoutTimer);
+        });
+    }
+
+    close() {
+        this._closedInMeantime = true;
+        clearTimeout(this._timeoutTimer);
+        this._abortController.abort();
+
+        this._opts.setState({
+            closed: true,
+        });
+
+        logPullState(`(IN-FLIGHT -> CLOSED) Closed!`);
+    }
+}
 
 export class TransportHttpClient<BagType extends FnsBag> implements ITransport<BagType> {
     status: Watchable<TransportStatus> = new Watchable('OPEN' as TransportStatus);
     deviceId: string;
     methods: BagType;
     connections: WatchableSet<IConnection<BagType>> = new WatchableSet();
-    _pullReschedules: Map<string, (ms?: number) => void> = new Map();
-    _scheduledPolls: Map<string, number> = new Map();
+    _pullStates: Map<
+        string,
+        InFlightPullState<BagType> | ScheduledPullState<BagType> | ClosedPullState
+    > = new Map();
 
     constructor(opts: ITransportOpts<BagType>) {
         log('constructor for device', opts.deviceId);
@@ -39,6 +191,7 @@ export class TransportHttpClient<BagType extends FnsBag> implements ITransport<B
 
         log('...closing connections...');
         for (const conn of this.connections) {
+            console.log('Closing connection', conn);
             conn.close();
         }
 
@@ -60,6 +213,7 @@ export class TransportHttpClient<BagType extends FnsBag> implements ITransport<B
                 // send envelope in its own HTTP POST.
                 // TODO: does this work right if it's called multiple times at once?
                 // probably conn.status ends up wrong.
+
                 if (conn.isClosed) throw new RpcErrorUseAfterClose('the connection is closed');
                 log(`connection "${conn.description}" is sending an envelope:`, env);
                 log('send...');
@@ -68,7 +222,7 @@ export class TransportHttpClient<BagType extends FnsBag> implements ITransport<B
                 const urlToPost = url + `from/${this.deviceId}`;
                 log(`send... POSTing to ${urlToPost}`);
 
-                const { request, cancel: cancelRequest } = fetchWithTimeout(
+                const { request, cancel: cancelRequest, clearFetchTimeout } = fetchWithTimeout(
                     TIMEOUT,
                     urlToPost,
                     {
@@ -82,11 +236,14 @@ export class TransportHttpClient<BagType extends FnsBag> implements ITransport<B
                 );
 
                 conn.onClose(() => {
+                    clearFetchTimeout();
                     cancelRequest();
                 });
 
                 try {
                     const res = await request;
+
+                    clearFetchTimeout();
 
                     if (this.isClosed) return;
 
@@ -101,15 +258,19 @@ export class TransportHttpClient<BagType extends FnsBag> implements ITransport<B
                         // cancel current pull timers for this connection
                         // and pull again!
 
-                        const cancelPollAndRetry = this._pullReschedules.get(conn.description);
+                        const pullState = this._pullStates.get(conn.description);
 
-                        if (cancelPollAndRetry) {
-                            cancelPollAndRetry();
+                        if (pullState && 'reschedule' in pullState) {
+                            logPullState(
+                                'Sent envelopes, expecting some back... let\'s reschedule!',
+                            );
+                            pullState.reschedule(0);
                         }
 
                         conn.status.set('OPEN');
                     }
                 } catch (error) {
+                    clearFetchTimeout();
                     // Don't throw if we're just cancelling the request
                     // Can't use DOMException here because Node doesn't have it.
                     // And need to support some node-fetch variant of this error too.
@@ -129,109 +290,21 @@ export class TransportHttpClient<BagType extends FnsBag> implements ITransport<B
             },
         });
 
-        // times we should wait in different conditions
-        const QUICK_POLL = 10; // got good data, try again right away
-        const SLOW_POLL = 1000; // got no data, slow down
-        const ERROR_POLL = 3000; // got an error, back off
+        const newPullState = new InFlightPullState({
+            connection: conn,
+            setState: (state) => this._pullStates.set(conn.description, state),
+            urlToFetch: url + `for/${this.deviceId}`,
+        });
 
-        // PULL
-        // Poll for a batch (array) of new envs by HTTP GET and send them to conn.handleIncomingEnvelope
-        // This loop ends when conn.status is CLOSED.
-        const pull = () => {
-            log('----- pull thread...');
-
-            if (this.isClosed) return;
-            const urlToGet = url + `for/${this.deviceId}`;
-
-            const { request, cancel: cancelRequest } = fetchWithTimeout(TIMEOUT, urlToGet);
-
-            request.then(async (response) => {
-                const reschedule = this._pullReschedules.get(conn.description);
-
-                try {
-                    if (this.isClosed) return;
-
-                    if (!response.ok) {
-                        throw new RpcErrorNetworkProblem('pull thread HTTP response was not ok');
-                    }
-
-                    const envs = await response.json();
-
-                    if (this.isClosed) return;
-
-                    if (!Array.isArray(envs)) throw new RpcError('expected an array');
-                    // poll slower when there's nothing there
-
-                    //sleepTime = envs.length >= 1 ? QUICK_POLL : SLOW_POLL;
-                    if (reschedule) {
-                        const nextPoll = envs.length >= 1 ? QUICK_POLL : SLOW_POLL;
-
-                        reschedule(nextPoll);
-                    }
-
-                    // pass envelopes to the connection to handle one at a time
-                    conn.status.set('OPEN');
-                    log(`got ${envs.length} envelopes`);
-                    for (const env of envs) {
-                        if (this.isClosed) return;
-                        await conn.handleIncomingEnvelope(env);
-                    }
-                } catch (error) {
-                    if (this.isClosed) return;
-
-                    if (
-                        error instanceof DOMException &&
-                        error.message === 'The signal has been aborted'
-                    ) {
-                        return;
-                    }
-
-                    conn.status.set('ERROR');
-                    if (reschedule) {
-                        reschedule(ERROR_POLL);
-                    }
-
-                    console.warn('> problem polling for envelopes:', error);
-                    // don't re-throw; swallow this error because there's nobody to catch it
-                }
-            }).catch(() => {
-                // The request may have been cancelled by us.
-                // We'll just catch the aborted error here.
-            });
-
-            const nextPoll = setTimeout(() => {
-                log(`Polled a pull on ${conn.description}`);
-                pull();
-            }, SLOW_POLL);
-
-            conn.onClose(() => {
-                clearTimeout(nextPoll);
-                cancelRequest();
-            });
-
-            const nextReschedule = (ms?: number) => {
-                log(`Rescheduling next pull ${ms ? `in ${ms}ms` : 'immediately'}...`);
-
-                clearTimeout(nextPoll);
-                const pullTimer = setTimeout(pull, ms);
-
-                conn.onClose(() => {
-                    clearTimeout(pullTimer);
-                });
-            };
-
-            const prevPoll = this._scheduledPolls.get(conn.description);
-            clearTimeout(prevPoll);
-            this._scheduledPolls.set(conn.description, nextPoll);
-
-            this._pullReschedules.set(conn.description, nextReschedule);
-
-            log(`Set up pull for ${conn.description}`);
-        };
-
-        pull();
+        this._pullStates.set(conn.description, newPullState);
 
         conn.onClose(() => {
+            const pullState = this._pullStates.get(conn.description);
+
+            if (pullState && pullState.closed === false) {
+                pullState.close();
+            }
+
             this.connections.delete(conn);
         });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,9 +17,6 @@ export function fetchWithTimeout(
     const request = fetch(input, { ...init, signal: controller.signal }).then((res) => {
         clearTimeout(timeoutId);
         return res;
-    }).catch((err) => {
-        clearTimeout(timeoutId);
-        return err as Response;
     });
 
     const cancel = () => {
@@ -29,7 +26,11 @@ export function fetchWithTimeout(
         }
     };
 
-    return { request, cancel };
+    const clearFetchTimeout = () => {
+        clearTimeout(timeoutId);
+    };
+
+    return { request, cancel, clearFetchTimeout };
 }
 
 export const withTimeout = async <T>(ms: number, prom: Promise<T>): Promise<T> => {


### PR DESCRIPTION
## What's the problem you solved?

I had turned `TransportHttpClient` into a ball of timeout spaghetti, which not only made it very hard to read but also meant that it was leaking timers.

## What solution are you recommending?

<img width="680" alt="CleanShot 2022-02-13 at 22 23 13@2x" src="https://user-images.githubusercontent.com/579491/153775621-84a33a55-fdcd-4146-a66b-c86a85b2c996.png">

I have refactored the 'pull' part of the Http client's into three classes representing the three possible states a pull can be in:

- `InFlightPullState`
- `ScheduledPullState`
- `ClosedPullState`

These classes have methods on them which allow them to transition to other valid states (e.g. `ScheduledPullState -> InFlightPullState` is fine, `ClosedPullState -> ScheduledPullState` is not!)

This makes the 'pull' part of the client a lot easier to understand and debug, and also makes it not leak anymore.
